### PR TITLE
fix answers order bug

### DIFF
--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -3,7 +3,7 @@
     = f.label :registered_on, '日付'
     = f.date_field :registered_on
   .form-item
-    = f.fields_for :answers do |answer_form|
+    = f.fields_for :answers, log.answers.sort_by(&:question_id) do |answer_form|
       = answer_form.object.question.content
       = answer_form.hidden_field :question_id, value: answer_form.object.question.id
       = answer_form.label :is_good_habit, 'はい'


### PR DESCRIPTION
編集ページにおいて、質問の内容が、回答のupdateed_atの順番に並んでしまい、意図しない形で順番が変わるバグがあったので修正しました。

古い記事だけど http://ken73g.blogspot.com/2010/09/fieldsfor.html が参考になった