### PR TITLE
logの作成時に表示されている選択肢の文字色と枠の色を統一する

### DIFF
--- a/app/assets/stylesheets/log.scss
+++ b/app/assets/stylesheets/log.scss
@@ -156,7 +156,8 @@
 .form_radio_label {
   transition: all 0.3s ease 0s;
   margin: 8px;
-  border: 1px solid $main-color;
+  border: 1px solid $button-color;
+  color: $button-color;
   display: block;
   padding: 12px 16px;
   border-radius: 4px;

--- a/app/assets/stylesheets/variable.scss
+++ b/app/assets/stylesheets/variable.scss
@@ -6,3 +6,4 @@ $text-color: #595959;
 $text-color-light: #D6D6D6;
 $border-color: #EAEAEA;
 $background-base-color: #FCFCFC;
+$button-color: #647CA5;


### PR DESCRIPTION
## issue
https://github.com/masanarih0ri/sleeple/issues/169